### PR TITLE
ABW nicht in parent-Liste aufnehmen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>de.muenchen.rbs</groupId>
 	<artifactId>kita-finder-eai</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<name>kita-finder-eai</name>
 	<description>Enterprise Application Interface zwischen Kita-App und
 		Kita-Finder</description>

--- a/src/main/java/de/muenchen/rbs/kitafindereai/api/model/Child.java
+++ b/src/main/java/de/muenchen/rbs/kitafindereai/api/model/Child.java
@@ -54,7 +54,7 @@ public class Child   {
     // Kitafinder-Column [WOHNHAFT_BEI]
     private ChildAddress address;
 
-    @Schema(description = "Array mit Sorgeberechtigten für das Kind. Liste wird aus SB1, SB2 und ABW berechnet.")
+    @Schema(description = "Array mit Sorgeberechtigten für das Kind. Liste wird aus SB1 und SB2 berechnet.")
     private Collection<Parent> parents;
 
 }

--- a/src/main/java/de/muenchen/rbs/kitafindereai/config/ModelMapperConfiguration.java
+++ b/src/main/java/de/muenchen/rbs/kitafindereai/config/ModelMapperConfiguration.java
@@ -119,8 +119,6 @@ public class ModelMapperConfiguration {
                     context.getSource().getSb1Nachname());
             addParentIfExists(parents, ParentType.sb2, context.getSource().getSb2Vorname(),
                     context.getSource().getSb2Nachname());
-            addParentIfExists(parents, ParentType.abw, context.getSource().getAbwVorname(),
-                    context.getSource().getAbwNachname());
 
             return parents;
         };

--- a/src/test/java/de/muenchen/rbs/kitafindereai/mapper/ModelMapperTest.java
+++ b/src/test/java/de/muenchen/rbs/kitafindereai/mapper/ModelMapperTest.java
@@ -104,10 +104,10 @@ class ModelMapperTest {
 
         Collection<Parent> parents = dest.getParents();
 
-        assertThat(parents).hasSize(3);
+        assertThat(parents).hasSize(2);
         assertThat(parents.stream().filter(p -> ParentType.sb1.equals(p.getParentType()))).hasSize(1);
         assertThat(parents.stream().filter(p -> ParentType.sb2.equals(p.getParentType()))).hasSize(1);
-        assertThat(parents.stream().filter(p -> ParentType.abw.equals(p.getParentType()))).hasSize(1);
+        assertThat(parents.stream().filter(p -> ParentType.abw.equals(p.getParentType()))).hasSize(0);
     }
 
     @Test


### PR DESCRIPTION
**Description**

In die Liste der Eltern wurden bisher Elternteil 1, Elternteil 2 und einen gegebenenfalls abweichende dritte Person übernommen. Die abweichende dritte Person soll nicht mit aufgenommen werden.
